### PR TITLE
use formData when creating patient

### DIFF
--- a/src/features/patients/pages/PatientForm.tsx
+++ b/src/features/patients/pages/PatientForm.tsx
@@ -72,9 +72,9 @@ export const PatientForm: FC = () => {
     }
 
     setIsSubmitting(true);
-    createPatient(patientFormRef?.current)
+    createPatient(patientFormRef?.current?.formData || {})
       .then(({ data }) =>
-        createNameNote(data.ID, patientEvent?.id || "", surveyFormRef?.current)
+        createNameNote(data.ID, patientEvent?.id || "", surveyFormRef?.current?.formData)
       )
       .then(() => {
         setIsSubmitting(false);


### PR DESCRIPTION
Fixes #21 
after adding the `isValid` and moving `formData` to an object, didn't update the call to create a patient