### PR TITLE
Add use of DescriptionField in SelectWidget and FieldTemplate

### DIFF
--- a/src/shared/components/DescriptionField.tsx
+++ b/src/shared/components/DescriptionField.tsx
@@ -1,0 +1,36 @@
+import { Box } from "@material-ui/core";
+import { Typography } from "@material-ui/core";
+
+type FieldProps = {
+  description?: string;
+  id?: string;
+  variant?: "caption" | "subtitle2";
+};
+
+export const DescriptionField = (props: FieldProps) => {
+  const { description = "", variant = "subtitle2" } = props;
+  if (!description) return null;
+
+  const lines = description.split("\n");
+  if (lines.length === 1)
+    return <Typography variant="subtitle2">{description}</Typography>;
+
+  return (
+    <>
+      {props.description
+        ?.split("\n")
+        .map((description: string, index: number) => (
+          <Typography
+            variant={variant}
+            style={{
+              marginBottom: 7,
+              whiteSpace: "normal",
+            }}
+            key={index}
+          >
+            {description}
+          </Typography>
+        ))}
+    </>
+  );
+};

--- a/src/shared/components/DescriptionField.tsx
+++ b/src/shared/components/DescriptionField.tsx
@@ -1,4 +1,3 @@
-import { Box } from "@material-ui/core";
 import { Typography } from "@material-ui/core";
 
 type FieldProps = {

--- a/src/shared/components/FieldTemplate.tsx
+++ b/src/shared/components/FieldTemplate.tsx
@@ -1,0 +1,140 @@
+import { FieldTemplateProps } from "@rjsf/core";
+import FormHelperText from "@material-ui/core/FormHelperText";
+import List from "@material-ui/core/List";
+import ListItem from "@material-ui/core/ListItem";
+import { utils } from "@rjsf/core";
+import { JSONSchema7 } from "json-schema";
+import Grid from "@material-ui/core/Grid";
+import FormControl from "@material-ui/core/FormControl";
+import Input from "@material-ui/core/Input";
+import InputLabel from "@material-ui/core/InputLabel";
+
+import { IconButton } from "./IconButton";
+import { DescriptionField } from "./DescriptionField";
+
+const { ADDITIONAL_PROPERTY_FLAG } = utils;
+
+type WrapIfAdditionalProps = {
+  children: React.ReactElement;
+  classNames: string;
+  disabled: boolean;
+  id: string;
+  label: string;
+  onDropPropertyClick: (index: string) => (event?: any) => void;
+  onKeyChange: (index: string) => (event?: any) => void;
+  readonly: boolean;
+  required: boolean;
+  schema: JSONSchema7;
+};
+
+const WrapIfAdditional = ({
+  children,
+  disabled,
+  id,
+  label,
+  onDropPropertyClick,
+  onKeyChange,
+  readonly,
+  required,
+  schema,
+}: WrapIfAdditionalProps) => {
+  const keyLabel = `${label} Key`; // i18n ?
+  const additional = schema.hasOwnProperty(ADDITIONAL_PROPERTY_FLAG);
+  const btnStyle = {
+    flex: 1,
+    paddingLeft: 6,
+    paddingRight: 6,
+    fontWeight: "bold",
+  };
+
+  if (!additional) {
+    return <>{children}</>;
+  }
+
+  const handleBlur = ({ target }: React.FocusEvent<HTMLInputElement>) =>
+    onKeyChange(target.value);
+
+  return (
+    <Grid container={true} key={`${id}-key`} alignItems="center" spacing={2}>
+      <Grid item={true} xs>
+        <FormControl fullWidth={true} required={required}>
+          <InputLabel>{keyLabel}</InputLabel>
+          <Input
+            defaultValue={label}
+            disabled={disabled || readonly}
+            id={`${id}-key`}
+            name={`${id}-key`}
+            onBlur={!readonly ? handleBlur : undefined}
+            type="text"
+          />
+        </FormControl>
+      </Grid>
+      <Grid item={true} xs>
+        {children}
+      </Grid>
+      <Grid item={true}>
+        <IconButton
+          icon="remove"
+          tabIndex={-1}
+          style={btnStyle as any}
+          disabled={disabled || readonly}
+          onClick={onDropPropertyClick(label)}
+        />
+      </Grid>
+    </Grid>
+  );
+};
+
+export const FieldTemplate = ({
+  id,
+  children,
+  classNames,
+  disabled,
+  displayLabel,
+  label,
+  onDropPropertyClick,
+  onKeyChange,
+  readonly,
+  required,
+  rawErrors = [],
+  rawHelp,
+  rawDescription,
+  schema,
+}: FieldTemplateProps) => {
+  return (
+    <WrapIfAdditional
+      classNames={classNames}
+      disabled={disabled}
+      id={id}
+      label={label}
+      onDropPropertyClick={onDropPropertyClick}
+      onKeyChange={onKeyChange}
+      readonly={readonly}
+      required={required}
+      schema={schema}
+    >
+      <FormControl
+        fullWidth={true}
+        error={rawErrors.length ? true : false}
+        required={required}
+      >
+        {children}
+        {displayLabel && rawDescription ? (
+          <DescriptionField variant="caption" description={rawDescription} />
+        ) : null}
+        {rawErrors.length > 0 && (
+          <List dense={true} disablePadding={true}>
+            {rawErrors.map((error, i: number) => {
+              return (
+                <ListItem key={i} disableGutters={true}>
+                  <FormHelperText id={id}>{error}</FormHelperText>
+                </ListItem>
+              );
+            })}
+          </List>
+        )}
+        {rawHelp && <FormHelperText id={id}>{rawHelp}</FormHelperText>}
+      </FormControl>
+    </WrapIfAdditional>
+  );
+};

--- a/src/shared/components/IconButton.tsx
+++ b/src/shared/components/IconButton.tsx
@@ -1,0 +1,29 @@
+import Button from "@material-ui/core/Button";
+import Add from "@material-ui/icons/Add";
+import ArrowUpward from "@material-ui/icons/ArrowUpward";
+import ArrowDownward from "@material-ui/icons/ArrowDownward";
+import Remove from "@material-ui/icons/Remove";
+import { IconButtonProps as MuiIconButtonProps } from "@material-ui/core/IconButton";
+
+const mappings: any = {
+  remove: Remove,
+  plus: Add,
+  "arrow-up": ArrowUpward,
+  "arrow-down": ArrowDownward,
+};
+
+type IconButtonProps = MuiIconButtonProps & {
+  icon: string;
+  iconProps?: object;
+};
+
+export const IconButton = (props: IconButtonProps) => {
+  const { icon, className, iconProps, ...otherProps } = props;
+  const IconComp = mappings[icon];
+  return (
+    // @ts-ignore
+    <Button {...otherProps} size="small">
+      <IconComp {...iconProps} />
+    </Button>
+  );
+};

--- a/src/shared/components/JsonSchemaForm.tsx
+++ b/src/shared/components/JsonSchemaForm.tsx
@@ -6,7 +6,8 @@ import { FormValidation } from "@rjsf/core";
 import { SelectWidget } from "./SelectWidget";
 import { DateWidget } from "./DateWidget";
 import { TimeWidget } from "./TimeWidget";
-import { Typography } from "@material-ui/core";
+import { FieldTemplate } from "./FieldTemplate";
+import { DescriptionField } from "./DescriptionField";
 
 const ajvErrors = require("ajv-errors");
 
@@ -21,36 +22,6 @@ const ajv = new Ajv({
 
 ajvErrors(ajv);
 
-type FieldProps = {
-  description?: string;
-  id?: string;
-};
-
-const DescriptionField = (props: FieldProps) => {
-  const { description = "" } = props;
-  if (!description) return null;
-
-  const lines = description.split("\n");
-  if (lines.length === 1)
-    return <Typography variant="subtitle2">{description}</Typography>;
-
-  return (
-    <>
-      {props.description
-        ?.split("\n")
-        .map((description: string, index: number) => (
-          <Typography
-            variant="subtitle2"
-            style={{ marginBottom: 7 }}
-            key={index}
-          >
-            {description}
-          </Typography>
-        ))}
-    </>
-  );
-};
-
 const widgets = {
   DateWidget,
   TimeWidget,
@@ -59,7 +30,7 @@ const widgets = {
 };
 
 const fields = {
-  DescriptionField: DescriptionField,
+  DescriptionField,
 };
 
 export type Props = {
@@ -86,6 +57,7 @@ export const JsonSchemaForm: FC<Props> = ({
     return (
       <Form
         id={id}
+        FieldTemplate={FieldTemplate}
         ErrorList={() => null}
         schema={jsonSchema}
         uiSchema={uiSchema}

--- a/src/shared/components/SelectWidget.tsx
+++ b/src/shared/components/SelectWidget.tsx
@@ -1,8 +1,10 @@
-import React, { useEffect } from "react";
+import React from "react";
 import MenuItem from "@material-ui/core/MenuItem";
 import TextField from "@material-ui/core/TextField";
 import { WidgetProps } from "@rjsf/core";
 import { utils } from "@rjsf/core";
+import { DescriptionField } from "./DescriptionField";
+import { Box } from "@material-ui/core";
 
 const { getUiOptions } = utils;
 
@@ -86,7 +88,9 @@ export const SelectWidget = ({
         enumDisabled && (enumDisabled as any).indexOf(value) !== -1;
       return (
         <MenuItem key={i} value={value} disabled={disabled}>
-          {label}
+          <Box alignItems="flex-start">
+            <DescriptionField description={value} />
+          </Box>
         </MenuItem>
       );
     }

--- a/src/shared/containers/ThemeProvider.tsx
+++ b/src/shared/containers/ThemeProvider.tsx
@@ -5,7 +5,7 @@ import {
   Palette as MuiPalette,
   PaletteColor,
 } from "@material-ui/core/styles";
-import { ThemeProvider as MuiThemeProvider,  } from "@material-ui/styles";
+import { ThemeProvider as MuiThemeProvider } from "@material-ui/styles";
 
 declare module "@material-ui/core/styles/createPalette" {
   interface Palette {
@@ -17,7 +17,7 @@ declare module "@material-ui/core/styles/createPalette" {
 }
 
 export interface Palette extends MuiPalette {
-  menubar: PaletteColor,
+  menubar: PaletteColor;
 }
 export interface Theme extends MuiTheme {
   palette: Palette;
@@ -42,6 +42,7 @@ const theme = {
       color: "#ecf3fc",
     },
     button: {},
+    caption: { color: "#9E9E9E" },
   },
 
   divider: "#333333",


### PR DESCRIPTION
- Description Field being used in the `FieldTemplate` so that the description text for field level components is handled
- Also used put it in `MenuItem` for selects- originally I had the severity back as the whole description in the menu item, but it still looked average.. doesn't seem to hurt to keep it here..

using the schema here : https://github.com/sussol/msupply/pull/8480