### PR TITLE
#40 evaluate date time widgets

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -30,6 +30,9 @@
       body {
         margin: 0;
       }
+      .MuiClock-clock {
+        font-family: 'Raleway';
+      }
     </style>
   </head>
   <body>

--- a/src/shared/components/DateWidget.tsx
+++ b/src/shared/components/DateWidget.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import { FC, useState } from "react";
 import { TextFieldProps } from "@material-ui/core";
 import MuiDatePicker from "@material-ui/lab/DatePicker";
 import AdapterDateFns from "@material-ui/lab/AdapterDateFns";
@@ -6,18 +6,25 @@ import LocalizationProvider from "@material-ui/lab/LocalizationProvider";
 import { format, isValid } from "date-fns";
 import { WidgetProps } from "@rjsf/core";
 import { TextWidget } from "./TextWidget";
-import enLocale from 'date-fns/locale/en-NZ';
+import enLocale from "date-fns/locale/en-NZ";
 
 // TODO: Fix typings for TextWidget
 export const DateWidget: FC<WidgetProps> = (props: any) => {
+  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
+  const handleDateChange = (date: Date | null) => {
+    if (isValid(date)) {
+      const validDate = date || new Date();
+      props.onChange(format(validDate, "dd/MM/yyyy"));
+      setSelectedDate(validDate);
+    }
+  };
+
   return (
     <LocalizationProvider dateAdapter={AdapterDateFns} locale={enLocale}>
       <MuiDatePicker
         label={props.label || props.schema.title}
-        value={props.value ?? null}
-        onChange={(newValue) => {
-          if (isValid(newValue)) props.onChange(format(newValue, "dd/MM/yyyy"));
-        }}
+        value={selectedDate}
+        onChange={(date) => handleDateChange(date)}
         renderInput={(params: TextFieldProps) => (
           <TextWidget {...params} {...props} />
         )}

--- a/src/shared/components/DateWidget.tsx
+++ b/src/shared/components/DateWidget.tsx
@@ -6,11 +6,12 @@ import LocalizationProvider from "@material-ui/lab/LocalizationProvider";
 import { format, isValid } from "date-fns";
 import { WidgetProps } from "@rjsf/core";
 import { TextWidget } from "./TextWidget";
+import enLocale from 'date-fns/locale/en-NZ';
 
 // TODO: Fix typings for TextWidget
 export const DateWidget: FC<WidgetProps> = (props: any) => {
   return (
-    <LocalizationProvider dateAdapter={AdapterDateFns}>
+    <LocalizationProvider dateAdapter={AdapterDateFns} locale={enLocale}>
       <MuiDatePicker
         label={props.label || props.schema.title}
         value={props.value ?? null}


### PR DESCRIPTION
Fixes #40 

Added a hacky global style to get the outer numbers on the TimeWidget clock to use the correct font.
Fixed an issue with the DatePicker - which prevented picking days > 12