### PR TITLE
map date_of_birth format

### DIFF
--- a/src/features/patients/hooks/usePatientApi.ts
+++ b/src/features/patients/hooks/usePatientApi.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
 import { getUrl } from "../../../shared/utils";
+import { format, parse } from "date-fns";
 interface PatientResponseData {
   ID: string;
   name: string;
@@ -12,9 +13,18 @@ interface PatientResponseData {
   postal_address1: string;
 }
 
+const mapPatientData = (patientData: any) => {
+  const { date_of_birth } = patientData;
+  const dob = parse(date_of_birth, "dd/MM/yyyy", new Date());
+  return {
+    ...patientData,
+    date_of_birth: format(dob, "yyyy-MM-dd"),
+  };
+};
+
 const createPatient = (patientData: any) =>
   axios
-    .post<PatientResponseData>(getUrl("patient"), patientData, {
+    .post<PatientResponseData>(getUrl("patient"), mapPatientData(patientData), {
       withCredentials: true,
     })
     .then(({ data }) => {


### PR DESCRIPTION
Fixes #56 

Really need to handle the dates better.. this is a patch to get `date_of_birth` saving in a 4D friendly format, while allowing entry in a locale friendly format. Perhaps sending as a date rather than a string would work.. though then we have timezone issues 🤔 