### PR TITLE
Add only show app after fonts have loaded

### DIFF
--- a/src/shared/containers/PreFetchContainer.tsx
+++ b/src/shared/containers/PreFetchContainer.tsx
@@ -1,6 +1,7 @@
 import { FC } from "react";
 import { useQueryClient } from "react-query";
 import { getAdrSchema } from "../../features/adr/pages/hooks/useADRSchemaQuery";
+import { useHaveFontsLoaded } from "../hooks/useFontLoading";
 import { getPatientSchema } from "../../features/patients/hooks/usePatientSchemaQuery";
 import { getPatientSurveySchema } from "../../features/patients/hooks/usePatientSurveySchemaQuery";
 import { useAuth } from "../hooks";
@@ -8,6 +9,7 @@ import { useAuth } from "../hooks";
 export const PreFetchContainer: FC = ({ children }) => {
   const queryClient = useQueryClient();
   const { username } = useAuth();
+  const fontsHaveLoaded = useHaveFontsLoaded();
 
   if (username) {
     queryClient.prefetchQuery("patientSurveySchema", getPatientSurveySchema);
@@ -15,5 +17,5 @@ export const PreFetchContainer: FC = ({ children }) => {
     queryClient.prefetchQuery("adrSchema", getAdrSchema);
   }
 
-  return <>{children}</>;
+  return <>{fontsHaveLoaded ? children : null}</>;
 };

--- a/src/shared/hooks/useFontLoading.ts
+++ b/src/shared/hooks/useFontLoading.ts
@@ -1,0 +1,22 @@
+import { useEffect } from "react";
+import { useToggle } from "./useToggle";
+
+export const useHaveFontsLoaded = () => {
+  const { turnOn, isOn } = useToggle(false);
+
+  useEffect(() => {
+    // A bit defensive as FontFace api is still technically experimental, even though it is
+    // supported by most browsers. TS doesn't support experimental apis
+    // https://caniuse.com/font-loading
+    const fontsApi = (document as any)?.fonts;
+    if (fontsApi) {
+      fontsApi.load("12px raleway").then(() => {
+        turnOn();
+      });
+    } else {
+      turnOn();
+    }
+  }, [turnOn]);
+
+  return isOn;
+};


### PR DESCRIPTION
I couldn't see much info on the flash of un-styled text (Noticeable mainly when throttling the browser to slow 3g speeds, which I imagine a lot of Tonga would be using.. maybe) with react, so I feel like there must be different/better solutions??

Would be way better with a skeleton component or something but it's not noticeable unless you're on a slow connection already

Did you solve this a completely different way for universal codes?

I know maybe this isnt the most highest priority but just trying to work my way through the list..