### PR TITLE
handle auth timeout in patient lookup

### DIFF
--- a/src/features/adr/components/PatientLookup.tsx
+++ b/src/features/adr/components/PatientLookup.tsx
@@ -72,10 +72,14 @@ export const PatientLookup: FC<PatientLookupProps> = ({
     error,
     noMore,
     loading,
+    refresh,
     searchedWithNoResults,
     searchOnline,
     searchMore,
   } = usePatientLookup();
+
+  const { isOpen, open } = useModal(ModalKey.login);
+  const { isGuest, username } = useAuth();
 
   const onSelect = (patient: Patient) => {
     const { ID, name } = patient;
@@ -96,31 +100,37 @@ export const PatientLookup: FC<PatientLookupProps> = ({
   const lookupPatients = useMemo(
     () => () => {
       if (loading || hasNoSearchParams) return;
+      if (isGuest) {
+        refresh();
+        return;
+      }
       searchOnline(searchParams);
     },
-    [searchOnline, hasNoSearchParams, loading, searchParams]
+    [searchOnline, hasNoSearchParams, loading, searchParams, isGuest, refresh]
   );
 
   useEnterHandler(lookupPatients);
-  const { isOpen, open } = useModal(ModalKey.login);
-  const { isGuest, username } = useAuth();
 
   // if authentication is required, show login modal
   useEffect(() => {
     if (authenticationRequired) {
       open();
-    } 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [authenticationRequired, username]);
 
   // if currently searching and the modal state changes and we have a valid user
-  // search again
   useEffect(() => {
-    if(username && !isOpen && !isGuest && loading) {
-      authenticated();
-      searchOnline(searchParams);
+    if (!username || isOpen || !loading) return;
+    // if the user has logged in as guest this time, refresh to display the guest version
+    if (isGuest) window.location.reload();
+
+    // the user has logged in again, search again
+    authenticated();
+    searchOnline(searchParams);
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    }  }, [isOpen])
+  }, [isOpen]);
 
   return (
     <Grid container direction="row" justifyContent="space-around">


### PR DESCRIPTION
Added a check for a 401 response in the search, and if we get one, set an `authenticationRequired` prop in the state.

if the component notices that, it pops up the login form - and on login will resume the search ( if the user is logged in & not a guest ).

This does open the possibility of a user logging in, timing out, and signing is as guest and then searching.
But I'm not too fussed about that. 