### PR TITLE
config to require auth

### DIFF
--- a/public/runtime-config.js
+++ b/public/runtime-config.js
@@ -1,4 +1,8 @@
 window["patientHubConfig"] = {
+  allowGuestAccess: {
+    adverseDrugReactions: true,
+    patients: true,
+  },
   autologin: {
     adverseDrugReactions: false,
     patients: false,

--- a/src/features/auth/components/LoginDialog.tsx
+++ b/src/features/auth/components/LoginDialog.tsx
@@ -1,4 +1,5 @@
 import { FC, KeyboardEvent } from "react";
+
 import Button from "@material-ui/core/Button";
 import Dialog from "@material-ui/core/Dialog";
 import {
@@ -14,6 +15,7 @@ import { LoadingButton } from "@material-ui/lab";
 import { useTranslations } from "../../../shared/hooks/useTranslations";
 import { AppBar } from "../../../shared/components/AppBar";
 import { useLoginQuery, useLoginForm, useAuth } from "../hooks";
+import { useConfig } from "../../../shared/hooks";
 
 export interface LoginDialogProps {
   open: boolean;
@@ -26,16 +28,11 @@ export const LoginDialog: FC<LoginDialogProps> = ({
   handleClose,
   canExit = false,
 }) => {
-  const {
-    username,
-    password,
-    setUsername,
-    setPassword,
-    reset,
-    isFilled,
-  } = useLoginForm();
+  const { username, password, setUsername, setPassword, reset, isFilled } =
+    useLoginForm();
   const { tryLogin, tryGuestLogin, isLoading, error } = useLoginQuery();
   const { login, guestLogin } = useAuth();
+  const { allowGuestAccess } = useConfig();
   const { messages } = useTranslations();
 
   const onNormalLogin = async () => {
@@ -122,16 +119,18 @@ export const LoginDialog: FC<LoginDialogProps> = ({
                 {messages.signIn}
               </LoadingButton>
               <Box mt={1} />
-              <Button
-                disabled={isLoading}
-                fullWidth
-                endIcon={<ChevronRight />}
-                variant="contained"
-                color="primary"
-                onClick={onGuestLogin}
-              >
-                {messages.continueGuest}
-              </Button>
+              {allowGuestAccess && (
+                <Button
+                  disabled={isLoading}
+                  fullWidth
+                  endIcon={<ChevronRight />}
+                  variant="contained"
+                  color="primary"
+                  onClick={onGuestLogin}
+                >
+                  {messages.continueGuest}
+                </Button>
+              )}
             </Grid>
           </Grid>
         </Grid>

--- a/src/features/auth/hooks/useAuth.ts
+++ b/src/features/auth/hooks/useAuth.ts
@@ -1,6 +1,6 @@
 import { AuthContext } from "../AuthProvider";
 import { useContext, useEffect } from "react";
-import { useModal } from "../../../shared/hooks";
+import { useConfig, useModal } from "../../../shared/hooks";
 import { ModalKey } from "../../../shared/containers/ModalProvider";
 
 export const useAuth = () => {
@@ -9,11 +9,13 @@ export const useAuth = () => {
 };
 
 export const useLoginPrompt = () => {
-  const { username } = useAuth();
+  const { username, isGuest } = useAuth();
   const { open } = useModal(ModalKey.login);
+  const { allowGuestAccess } = useConfig();
+  const loginRequired = !username || (isGuest && !allowGuestAccess);
 
   useEffect(() => {
-    if (!username) open();
+    if (loginRequired) open();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 };

--- a/src/shared/hooks/useConfig.ts
+++ b/src/shared/hooks/useConfig.ts
@@ -1,4 +1,10 @@
+import { useLocation } from "react-router-dom";
+
 export type AppConfig = {
+  allowGuestAccess: {
+    patients: boolean;
+    adverseDrugReactions: boolean;
+  };
   autologin: {
     patients: boolean;
     adverseDrugReactions: boolean;
@@ -11,7 +17,29 @@ declare global {
   }
 }
 
+interface LocationState {
+  pathname: string;
+}
+const getRoute = (location: LocationState) => {
+  const route = (location?.pathname ?? "").split("/")[1];
+
+  switch (route) {
+    case "patients":
+      return "patients";
+    case "adverse-drug-reactions":
+      return "adverseDrugReactions";
+    default:
+      return undefined;
+  }
+};
 export const useConfig = () => {
   const { patientHubConfig } = window;
-  return patientHubConfig;
+  const location = useLocation();
+
+  const route = getRoute(location);
+  const allowGuestAccess = route
+    ? patientHubConfig.allowGuestAccess[route]
+    : true;
+
+  return { ...patientHubConfig, allowGuestAccess };
 };


### PR DESCRIPTION
Fixes #105 
Extends the configuration to add a route-specific option that disables guest access.
If disabled, the login prompt doesn't show guest login as an option and the router forces the login prompt.

To test: 

- [ ] try to register a patient or record and ADR: both should work
- [ ] disable guest access for patients and try the patient access from the main screen: should prompt for access, with no option to sign in as guest
- [ ] disable guest access for patients, login as guest and navigate to the patient registration: should prompt for access