### PR TITLE
change date format

### DIFF
--- a/src/shared/components/DateWidget.tsx
+++ b/src/shared/components/DateWidget.tsx
@@ -15,12 +15,12 @@ export const DateWidget: FC<WidgetProps> = (props: any) => {
   const handleDateChange = (date: Date | null) => {
     if (isValid(date)) {
       const validDate = date || new Date();
-      props.onChange(format(validDate, "dd/MM/yyyy"));
+      props.onChange(format(validDate, "yyyy-MM-dd"));
     }
   };
 
   const getDateValue = () => {
-    const asDate = parse(value, "dd/MM/yyyy", new Date());
+    const asDate = parse(value, "yyyy-MM-dd", new Date());
     return isValid(asDate) ? asDate : null;
   };
 


### PR DESCRIPTION
Fixes: #104 

quick update to the format - internally using the `yyyy-MM-dd` format, as per the regex and mobile, while still using the locale in the date picker which displays in the NZ format: `dd/mm/yyyy`

Without this, the dates were not being accepted 🙄 