### PR TITLE
retain patient name

### DIFF
--- a/src/features/adr/pages/ADRForm.tsx
+++ b/src/features/adr/pages/ADRForm.tsx
@@ -15,10 +15,17 @@ import { PatientForm } from "./PatientForm";
 import { ModalKey } from "../../../shared/containers/ModalProvider";
 
 import { Typography } from "@material-ui/core";
+import { useLayoutEffect } from "react";
+import { Patient } from "../../patients/types";
 
 const PatientName: FC = () => {
+  const [patient, setPatient] = useState<Patient>();
   const { data = {} } = useStep(0);
-  const { patient = {} } = data;
+  const { patient: newPatient } = data;
+
+  useLayoutEffect(() => {
+    if (newPatient) setPatient(newPatient);
+  }, [newPatient]);
 
   return patient ? <Typography variant="h6">{patient.name}</Typography> : null;
 };


### PR DESCRIPTION
Fixes #114 

The problem is that the new `useState` causes the `Stepper` to reload, losing state. the patient is set, and then lost again.
This is a quick, and fairly dirty, fix - to retain the patient internally in the name display component using internal state.