### PR TITLE
show errors in time picker; default to blank

### DIFF
--- a/src/shared/components/DateWidget.tsx
+++ b/src/shared/components/DateWidget.tsx
@@ -15,12 +15,12 @@ export const DateWidget: FC<WidgetProps> = (props: any) => {
   const handleDateChange = (date: Date | null) => {
     if (isValid(date)) {
       const validDate = date || new Date();
-      props.onChange(format(validDate, "yyyy-MM-dd"));
+      props.onChange(format(validDate, "dd/MM/yyyy"));
     }
   };
 
   const getDateValue = () => {
-    const asDate = parse(value, "yyyy-MM-dd", new Date());
+    const asDate = parse(value, "dd/MM/yyyy", new Date());
     return isValid(asDate) ? asDate : null;
   };
 

--- a/src/shared/components/TextWidget.tsx
+++ b/src/shared/components/TextWidget.tsx
@@ -5,8 +5,13 @@ import TextField, {
 } from "@material-ui/core/TextField";
 
 import { WidgetProps, utils } from "@rjsf/core";
+import { JSONSchema7 } from "json-schema";
 
 const { getDisplayLabel } = utils;
+
+interface ErrorSchema extends JSONSchema7 {
+  errorMessage?: string;
+}
 
 export type TextWidgetProps = WidgetProps & TextFieldProps;
 
@@ -47,6 +52,11 @@ export const TextWidget = ({
   );
   const inputType =
     (type || schema.type) === "string" ? "text" : `${type || schema.type}`;
+
+  const { errorMessage } = schema as ErrorSchema;
+  if (textFieldProps.error && errorMessage) {
+    textFieldProps.helperText = errorMessage;
+  }
 
   return (
     <TextField

--- a/src/shared/components/TimeWidget.tsx
+++ b/src/shared/components/TimeWidget.tsx
@@ -10,7 +10,7 @@ import { TextWidget } from "./TextWidget";
 // TODO: Fix typings for TextWidget
 export const TimeWidget: FC<WidgetProps> = (props: any) => {
   const { onChange, value } = props;
-  const [time, setTime] = useState(value);
+  const [time, setTime] = useState(value || "");
 
   return (
     <LocalizationProvider dateAdapter={AdapterDateFns}>


### PR DESCRIPTION
Fixes #118 

Updated the time picker so that it defaults to a blank value rather than the current time.
Also fixed the helper text which now displays correctly if the time picker is in an error state.

Changed the date format so that the date picker works again.